### PR TITLE
Update install.rst

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -34,7 +34,7 @@ Installation from source distributions files gives
 
 Basic steps::
 
-    git clone https://github.com/beave/meer
+    git clone https://github.com/quadrantsec/meer
     cd meer
     ./autogen.sh
     ./configure


### PR DESCRIPTION
the repo https://github.com/beave/meer is no longer being used. 
Instead it has been updated to https://github.com/quadrantsec/meer